### PR TITLE
Add 'module-resolver' babel plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "@babel/preset-typescript": "7.18.6",
     "babel-plugin-dynamic-import-node": "2.3.3",
     "babel-plugin-lodash": "3.3.4",
+    "babel-plugin-module-resolver": "4.1.0",
     "babel-plugin-styled-components": "2.0.7",
     "babel-plugin-transform-vue-jsx": "3.7.0",
     "babel-plugin-transform-vue-tsx": "3510.0.3"


### PR DESCRIPTION
Added `babel-plugin-module-resolver` to use `module-resolver` babel plugin through `@shelf/babel-config/backend` to use path aliases